### PR TITLE
DynamoDB backend

### DIFF
--- a/physical/dynamodb.go
+++ b/physical/dynamodb.go
@@ -1,0 +1,606 @@
+package physical
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+const (
+	// The default AWS region for the DynamoDB table which is
+	// used if none is configured explicitely.
+	DefaultDynamoDBRegion = "us-east-1"
+	// The default name for the DynamoDB table which is used
+	// if none is configured explicitely.
+	DefaultDynamoDBTableName = "vault-dynamodb-backend"
+
+	// The default DynamoDB read capacity to provision.
+	DefaultDynamoDBReadCapacity = 5
+	// The default DynamoDB write capacity to provision.
+	DefaultDynamoDBWriteCapacity = 5
+
+	// Since DynamoDB does not support empty strings, we
+	// 'escape' the root path with a space character.
+	DynamoDBEmptyPath = " "
+	// The lock prefix is used to mark DynamoDB records
+	// as locks which causes them not to be returned by
+	// List operations.
+	DynamoDBLockPrefix = "_"
+
+	// The amount of time to wait if a lock fails before
+	// trying again.
+	DynamoDBLockRetryInterval = time.Second
+	// The number of times to re-try a failed watch before
+	// signaling that leadership is lost.
+	DynamoDBWatchRetryMax = 5
+	// The amount of time to wait if a watch fails before
+	// trying again.
+	DynamoDBWatchRetryInterval = 5 * time.Second
+)
+
+// DynamoDBBackend is a physical backend that stores data in
+// a DynamoDB table. It can be run in high-availability mode
+// as DynamoDB has locking capabilities.
+type DynamoDBBackend struct {
+	table  string
+	client *dynamodb.DynamoDB
+}
+
+// DynamoDBRecord is the representation of a vault entry in
+// DynamoDB. The vault key is split up into two components
+// (Path and Key) in order to allow more efficient listings.
+type DynamoDBRecord struct {
+	Path  string
+	Key   string
+	Value []byte
+}
+
+// DynamoDBLock implements a lock using an DynamoDB client.
+type DynamoDBLock struct {
+	backend    *DynamoDBBackend
+	value, key string
+	held       bool
+	lock       sync.Mutex
+}
+
+// newDynamoDBBackend constructs a DynamoDB backend. If the
+// configured DynamoDB table does not exist, it creates it.
+func newDynamoDBBackend(conf map[string]string) (Backend, error) {
+	table := os.Getenv("AWS_DYNAMODB_TABLE")
+	if table == "" {
+		table = conf["table"]
+		if table == "" {
+			table = DefaultDynamoDBTableName
+		}
+	}
+	readCapacityString := os.Getenv("AWS_DYNAMODB_READ_CAPACITY")
+	if readCapacityString == "" {
+		readCapacityString = conf["read_capacity"]
+		if readCapacityString == "" {
+			readCapacityString = "0"
+		}
+	}
+	readCapacity, err := strconv.Atoi(readCapacityString)
+	if err != nil {
+		return nil, fmt.Errorf("invalid read capacity: %s", readCapacityString)
+	}
+	if readCapacity == 0 {
+		readCapacity = DefaultDynamoDBReadCapacity
+	}
+
+	writeCapacityString := os.Getenv("AWS_DYNAMODB_WRITE_CAPACITY")
+	if writeCapacityString == "" {
+		writeCapacityString = conf["write_capacity"]
+		if writeCapacityString == "" {
+			writeCapacityString = "0"
+		}
+	}
+	writeCapacity, err := strconv.Atoi(writeCapacityString)
+	if err != nil {
+		return nil, fmt.Errorf("invalid write capacity: %s", writeCapacityString)
+	}
+	if writeCapacity == 0 {
+		writeCapacity = DefaultDynamoDBWriteCapacity
+	}
+
+	access_key, ok := conf["access_key"]
+	if !ok {
+		access_key = ""
+	}
+	secret_key, ok := conf["secret_key"]
+	if !ok {
+		secret_key = ""
+	}
+	session_token, ok := conf["session_token"]
+	if !ok {
+		session_token = ""
+	}
+	endpoint := os.Getenv("AWS_DYNAMODB_ENDPOINT")
+	if endpoint == "" {
+		endpoint = conf["endpoint"]
+	}
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = conf["region"]
+		if region == "" {
+			region = DefaultDynamoDBRegion
+		}
+	}
+
+	creds := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.StaticProvider{Value: credentials.Value{
+			AccessKeyID:     access_key,
+			SecretAccessKey: secret_key,
+			SessionToken:    session_token,
+		}},
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())},
+	})
+
+	awsConf := aws.NewConfig().
+		WithCredentials(creds).
+		WithRegion(region).
+		WithEndpoint(endpoint)
+	client := dynamodb.New(session.New(awsConf))
+
+	if err := ensureTableExists(client, table, readCapacity, writeCapacity); err != nil {
+		return nil, err
+	}
+
+	return &DynamoDBBackend{
+		table:  table,
+		client: client,
+	}, nil
+}
+
+// Put is used to insert or update an entry
+func (d *DynamoDBBackend) Put(entry *Entry) error {
+	defer metrics.MeasureSince([]string{"dynamodb", "put"}, time.Now())
+
+	record := DynamoDBRecord{
+		Path:  recordPathForVaultKey(entry.Key),
+		Key:   recordKeyForVaultKey(entry.Key),
+		Value: entry.Value,
+	}
+	item, err := dynamodbattribute.ConvertToMap(record)
+	if err != nil {
+		return fmt.Errorf("could not convert prefix record to DynamoDB item: %s", err)
+	}
+	requests := []*dynamodb.WriteRequest{{
+		PutRequest: &dynamodb.PutRequest{
+			Item: item,
+		},
+	}}
+
+	for _, prefix := range prefixes(entry.Key) {
+		record = DynamoDBRecord{
+			Path: recordPathForVaultKey(prefix),
+			Key:  fmt.Sprintf("%s/", recordKeyForVaultKey(prefix)),
+		}
+		item, err := dynamodbattribute.ConvertToMap(record)
+		if err != nil {
+			return fmt.Errorf("could not convert prefix record to DynamoDB item: %s", err)
+		}
+		requests = append(requests, &dynamodb.WriteRequest{
+			PutRequest: &dynamodb.PutRequest{
+				Item: item,
+			},
+		})
+	}
+
+	return d.batchWriteRequests(requests)
+}
+
+// Get is used to fetch an entry
+func (d *DynamoDBBackend) Get(key string) (*Entry, error) {
+	defer metrics.MeasureSince([]string{"dynamodb", "get"}, time.Now())
+
+	resp, err := d.client.GetItem(&dynamodb.GetItemInput{
+		TableName:      aws.String(d.table),
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]*dynamodb.AttributeValue{
+			"Path": {S: aws.String(recordPathForVaultKey(key))},
+			"Key":  {S: aws.String(recordKeyForVaultKey(key))},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Item == nil {
+		return nil, nil
+	}
+
+	record := &DynamoDBRecord{}
+	if err := dynamodbattribute.ConvertFromMap(resp.Item, record); err != nil {
+		return nil, err
+	}
+
+	return &Entry{
+		Key:   vaultKey(record),
+		Value: record.Value,
+	}, nil
+}
+
+// Delete is used to permanently delete an entry
+func (d *DynamoDBBackend) Delete(key string) error {
+	defer metrics.MeasureSince([]string{"dynamodb", "delete"}, time.Now())
+
+	requests := []*dynamodb.WriteRequest{{
+		DeleteRequest: &dynamodb.DeleteRequest{
+			Key: map[string]*dynamodb.AttributeValue{
+				"Path": {S: aws.String(recordPathForVaultKey(key))},
+				"Key":  {S: aws.String(recordKeyForVaultKey(key))},
+			},
+		},
+	}}
+
+	// clean up now empty 'folders'
+	prefixes := prefixes(key)
+	sort.Sort(sort.Reverse(sort.StringSlice(prefixes)))
+	for _, prefix := range prefixes {
+		items, err := d.List(prefix)
+		if err != nil {
+			return err
+		}
+		if len(items) == 1 {
+			requests = append(requests, &dynamodb.WriteRequest{
+				DeleteRequest: &dynamodb.DeleteRequest{
+					Key: map[string]*dynamodb.AttributeValue{
+						"Path": {S: aws.String(recordPathForVaultKey(prefix))},
+						"Key":  {S: aws.String(fmt.Sprintf("%s/", recordKeyForVaultKey(prefix)))},
+					},
+				},
+			})
+		}
+	}
+
+	return d.batchWriteRequests(requests)
+}
+
+// List is used to list all the keys under a given
+// prefix, up to the next prefix.
+func (d *DynamoDBBackend) List(prefix string) ([]string, error) {
+	defer metrics.MeasureSince([]string{"dynamodb", "list"}, time.Now())
+
+	prefix = strings.TrimSuffix(prefix, "/")
+
+	keys := []string{}
+	prefix = escapeEmptyPath(prefix)
+	queryInput := &dynamodb.QueryInput{
+		TableName:      aws.String(d.table),
+		ConsistentRead: aws.Bool(true),
+		KeyConditions: map[string]*dynamodb.Condition{
+			"Path": {
+				ComparisonOperator: aws.String("EQ"),
+				AttributeValueList: []*dynamodb.AttributeValue{{
+					S: aws.String(prefix),
+				}},
+			},
+		},
+	}
+	err := d.client.QueryPages(queryInput, func(out *dynamodb.QueryOutput, lastPage bool) bool {
+		var record DynamoDBRecord
+		for _, item := range out.Items {
+			dynamodbattribute.ConvertFromMap(item, &record)
+			if !strings.HasPrefix(record.Key, DynamoDBLockPrefix) {
+				keys = append(keys, record.Key)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return keys, nil
+}
+
+// Lock is used for mutual exclusion based on the given key.
+func (d *DynamoDBBackend) LockWith(key, value string) (Lock, error) {
+	return &DynamoDBLock{
+		backend: d,
+		key:     filepath.Join(filepath.Dir(key), DynamoDBLockPrefix+filepath.Base(key)),
+		value:   value,
+	}, nil
+}
+
+// batchWriteRequests takes a list of write requests and executes them in badges
+// with a maximum size of 25 (which is the limit of BatchWriteItem requests).
+func (d *DynamoDBBackend) batchWriteRequests(requests []*dynamodb.WriteRequest) error {
+	for len(requests) > 0 {
+		batchSize := int(math.Min(float64(len(requests)), 25))
+		batch := requests[:batchSize]
+		requests = requests[batchSize:]
+
+		_, err := d.client.BatchWriteItem(&dynamodb.BatchWriteItemInput{
+			RequestItems: map[string][]*dynamodb.WriteRequest{
+				d.table: batch,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Lock tries to acquire the lock by repeatedly trying to create
+// a record in the DynamoDB table. It will block until either the
+// stop channel is closed or the lock could be acquired successfully.
+// The returned channel will be closed once the lock is deleted or
+// changed in the DynamoDB table.
+func (l *DynamoDBLock) Lock(stopCh <-chan struct{}) (doneCh <-chan struct{}, retErr error) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if l.held {
+		return nil, fmt.Errorf("lock already held")
+	}
+
+	done := make(chan struct{})
+	// close done channel even in case of error
+	defer func() {
+		if retErr != nil {
+			close(done)
+		}
+	}()
+
+	var (
+		stop    = make(chan struct{})
+		success = make(chan struct{})
+		errors  = make(chan error)
+		leader  = make(chan struct{})
+	)
+	// try to acquire the lock asynchronously
+	go l.tryToLock(stop, success, errors)
+
+	select {
+	case <-success:
+		l.held = true
+		// after acquiring it successfully, we must watch
+		// the lock in order to close the leader channel
+		// once it is lost.
+		go l.watch(leader)
+	case retErr = <-errors:
+		close(stop)
+		return nil, retErr
+	case <-stopCh:
+		close(stop)
+		return nil, nil
+	}
+
+	return leader, retErr
+}
+
+// Unlock releases the lock by deleting the lock record from the
+// DynamoDB table.
+func (l *DynamoDBLock) Unlock() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if !l.held {
+		return nil
+	}
+
+	l.held = false
+	if err := l.backend.Delete(l.key); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Value checks whether or not the lock is held by any instance of DynamoDBLock,
+// including this one, and returns the current value.
+func (l *DynamoDBLock) Value() (bool, string, error) {
+	entry, err := l.backend.Get(l.key)
+	if err != nil {
+		return false, "", err
+	}
+	if entry == nil {
+		return false, "", nil
+	}
+
+	return true, string(entry.Value), nil
+}
+
+// tryToLock tries to create a new item in DynamoDB
+// every `DynamoDBLockRetryInterval`. As long as the item
+// cannot be created (because it already exists), it will
+// be retried. If the operation fails due to an error, it
+// is sent to the errors channel.
+// When the lock could be acquired successfully, the success
+// channel is closed.
+func (l *DynamoDBLock) tryToLock(stop, success chan struct{}, errors chan error) {
+	ticker := time.NewTicker(DynamoDBLockRetryInterval)
+
+	record := DynamoDBRecord{
+		Path:  recordPathForVaultKey(l.key),
+		Key:   recordKeyForVaultKey(l.key),
+		Value: []byte(l.value),
+	}
+	item, err := dynamodbattribute.ConvertToMap(record)
+	if err != nil {
+		errors <- err
+		return
+	}
+
+	for {
+		select {
+		case <-stop:
+			ticker.Stop()
+		case <-ticker.C:
+			_, err := l.backend.client.PutItem(&dynamodb.PutItemInput{
+				TableName:           aws.String(l.backend.table),
+				Item:                item,
+				ConditionExpression: aws.String("attribute_not_exists(#p) or attribute_not_exists(#k)"),
+				ExpressionAttributeNames: map[string]*string{
+					"#p": aws.String("Path"),
+					"#k": aws.String("Key"),
+				},
+			})
+			if err != nil {
+				if err, ok := err.(awserr.Error); ok && err.Code() != "ConditionalCheckFailedException" {
+					errors <- err
+				}
+			} else {
+				ticker.Stop()
+				close(success)
+			}
+		}
+	}
+}
+
+// watch checks whether the lock has changed in the
+// DynamoDB table and closes the leader channel if so.
+// The interval is set by `DynamoDBWatchRetryInterval`.
+// If an error occurs during the check, watch will retry
+// the operation for `DynamoDBWatchRetryMax` times and
+// close the leader channel if it can't succeed.
+func (l *DynamoDBLock) watch(lost chan struct{}) {
+	retries := DynamoDBWatchRetryMax
+
+	ticker := time.NewTicker(DynamoDBWatchRetryInterval)
+WatchLoop:
+	for {
+		select {
+		case <-ticker.C:
+			item, err := l.backend.Get(l.key)
+			if err != nil {
+				retries -= 1
+				if retries == 0 {
+					break WatchLoop
+				}
+				continue
+			}
+
+			if item == nil || string(item.Value) != l.value {
+				break WatchLoop
+			}
+		}
+	}
+
+	close(lost)
+}
+
+// ensureTableExists creates a DynamoDB table with a given
+// DynamoDB client. If the table already exists, it is not
+// being reconfigured.
+func ensureTableExists(client *dynamodb.DynamoDB, table string, readCapacity, writeCapacity int) error {
+	_, err := client.DescribeTable(&dynamodb.DescribeTableInput{
+		TableName: aws.String(table),
+	})
+	if awserr, ok := err.(awserr.Error); ok {
+		if awserr.Code() == "ResourceNotFoundException" {
+			_, err = client.CreateTable(&dynamodb.CreateTableInput{
+				TableName: aws.String(table),
+				ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+					ReadCapacityUnits:  aws.Int64(int64(readCapacity)),
+					WriteCapacityUnits: aws.Int64(int64(writeCapacity)),
+				},
+				KeySchema: []*dynamodb.KeySchemaElement{{
+					AttributeName: aws.String("Path"),
+					KeyType:       aws.String("HASH"),
+				}, {
+					AttributeName: aws.String("Key"),
+					KeyType:       aws.String("RANGE"),
+				}},
+				AttributeDefinitions: []*dynamodb.AttributeDefinition{{
+					AttributeName: aws.String("Path"),
+					AttributeType: aws.String("S"),
+				}, {
+					AttributeName: aws.String("Key"),
+					AttributeType: aws.String("S"),
+				}},
+			})
+			if err != nil {
+				return err
+			}
+
+			err = client.WaitUntilTableExists(&dynamodb.DescribeTableInput{
+				TableName: aws.String(table),
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// recordPathForVaultKey transforms a vault key into
+// a value suitable for the `DynamoDBRecord`'s `Path`
+// property. This path equals the the vault key without
+// its last component.
+func recordPathForVaultKey(key string) string {
+	if strings.Contains(key, "/") {
+		return filepath.Dir(key)
+	}
+	return DynamoDBEmptyPath
+}
+
+// recordKeyForVaultKey transforms a vault key into
+// a value suitable for the `DynamoDBRecord`'s `Key`
+// property. This path equals the the vault key's
+// last component.
+func recordKeyForVaultKey(key string) string {
+	return filepath.Base(key)
+}
+
+// vaultKey returns the vault key for a given record
+// from the DynamoDB table. This is the combination of
+// the records Path and Key.
+func vaultKey(record *DynamoDBRecord) string {
+	path := unescapeEmptyPath(record.Path)
+	if path == "" {
+		return record.Key
+	}
+	return filepath.Join(record.Path, record.Key)
+}
+
+// escapeEmptyPath is used to escape the root key's path
+// with a value that can be stored in DynamoDB. DynamoDB
+// does not allow values to be empty strings.
+func escapeEmptyPath(s string) string {
+	if s == "" {
+		return DynamoDBEmptyPath
+	}
+	return s
+}
+
+// unescapeEmptyPath is the opposite of `escapeEmptyPath`.
+func unescapeEmptyPath(s string) string {
+	if s == DynamoDBEmptyPath {
+		return ""
+	}
+	return s
+}
+
+// prefixes returns all parent 'folders' for a given
+// vault key.
+// e.g. for 'foo/bar/baz', it returns ['foo', 'foo/bar']
+func prefixes(s string) []string {
+	components := strings.Split(s, "/")
+	result := []string{}
+	for i := 1; i < len(components); i++ {
+		result = append(result, strings.Join(components[:i], "/"))
+	}
+	return result
+}

--- a/physical/dynamodb_test.go
+++ b/physical/dynamodb_test.go
@@ -1,0 +1,113 @@
+package physical
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+func TestDynamoDBBackend(t *testing.T) {
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		t.SkipNow()
+	}
+
+	creds, err := credentials.NewEnvCredentials().Get()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// If the variable is empty or doesn't exist, the default
+	// AWS endpoints will be used
+	endpoint := os.Getenv("AWS_DYNAMODB_ENDPOINT")
+
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	conn := dynamodb.New(session.New(&aws.Config{
+		Credentials: credentials.NewEnvCredentials(),
+		Endpoint:    aws.String(endpoint),
+		Region:      aws.String(region),
+	}))
+
+	var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	table := fmt.Sprintf("vault-dynamodb-testacc-%d", randInt)
+
+	defer func() {
+		conn.DeleteTable(&dynamodb.DeleteTableInput{
+			TableName: aws.String(table),
+		})
+	}()
+
+	b, err := NewBackend("dynamodb", map[string]string{
+		"access_key":    creds.AccessKeyID,
+		"secret_key":    creds.SecretAccessKey,
+		"session_token": creds.SessionToken,
+		"table":         table,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	testBackend(t, b)
+	testBackend_ListPrefix(t, b)
+}
+
+func TestDynamoDBHABackend(t *testing.T) {
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		t.SkipNow()
+	}
+
+	creds, err := credentials.NewEnvCredentials().Get()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// If the variable is empty or doesn't exist, the default
+	// AWS endpoints will be used
+	endpoint := os.Getenv("AWS_DYNAMODB_ENDPOINT")
+
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	conn := dynamodb.New(session.New(&aws.Config{
+		Credentials: credentials.NewEnvCredentials(),
+		Endpoint:    aws.String(endpoint),
+		Region:      aws.String(region),
+	}))
+
+	var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	table := fmt.Sprintf("vault-dynamodb-testacc-%d", randInt)
+
+	defer func() {
+		conn.DeleteTable(&dynamodb.DeleteTableInput{
+			TableName: aws.String(table),
+		})
+	}()
+
+	b, err := NewBackend("dynamodb", map[string]string{
+		"access_key":    creds.AccessKeyID,
+		"secret_key":    creds.SecretAccessKey,
+		"session_token": creds.SessionToken,
+		"table":         table,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	ha, ok := b.(HABackend)
+	if !ok {
+		t.Fatalf("dynamodb does not implement HABackend")
+	}
+	testHABackend(t, ha, ha)
+}

--- a/physical/physical.go
+++ b/physical/physical.go
@@ -85,6 +85,7 @@ var BuiltinBackends = map[string]Factory{
 	"zookeeper": newZookeeperBackend,
 	"file":      newFileBackend,
 	"s3":        newS3Backend,
+	"dynamodb":  newDynamoDBBackend,
 	"etcd":      newEtcdBackend,
 	"mysql":     newMySQLBackend,
 }


### PR DESCRIPTION
This PR adds support for DynamoDB as HA backend to Vault. DynamoDB is a highly scalable, managed service provided as part of the Amazon Web Services. I think it would make a great storage backend for Vault as it requires almost no maintenance.

Due to DynamoDB's conditional write capability, it is possible to implement a distributed locking mechanism on top of it. Therefore, we can use it as a HA backend for Vault.
### Data Model

To map Vault's hierarchical data model to DynamoDB's key/value and document-oriented data model, and still be able to query the backend efficiently, this PR splits the Vault keys into two components: a `path` and a `key`:
- `foo` becomes `Path: "", Key: "foo"`
- `foo/bar` becomse `Path:"foo", Key: "bar"`

This way, the backend's `List` operation can be implemented with a DynamoDB `Query` API call that lists all keys under a given path. In order to list 'sub-folders' (`foo/` in the examples above) as well, a pseudo record `Path: "", Key: "foo/"` is inserted for the 'folder' `foo`.

This data model means that the memory and also computational complexity of `Put` and `Delete` operations is `O(c)` where `c` is the number of path components in the Vault key. To make this more efficient, this PR uses DynamoDB's `BatchWriteItem` API which performs writes in batches of 25.

Locking is done via the same data model with a prefix in the lock entries' keys. This prefix is used to exclude locks from the result of `List` operations. To ensure atomicity, the locking mechanism is implemented via DynamoDB's conditional writes which allow us to only create a lock record if it does not yet exist.
### Configuration

This backend has several configuration options:
- the **DynamoDB table** to use.. Can be configured either via an environment variable `AWS_DYNAMODB_TABLE` or via a `table` option in the server's config file. If this table does not exist yet, it is created during bootstrap.
- the **DynamoDB read capacity** to provision when creating the table. Can be configured wither via an environment varialbe `AWS_DYNAMODB_READ_CAPACITY` or via the `read_capacity` option in the server's config file.
- the **DynamoDB write capacity** to provision when creating the table. Can be configured wither via an environment varialbe `AWS_DYNAMODB_WRITE_CAPACITY` or via the `write_capacity` option in the server's config file.
- the **AWS IAM access key** to authenticate with. Can be configured via an environment variable `AWS_ACCESS_KEY_ID` or via a `access_key` option in the server's config file.
- the **AWS IAM secret key** to authenticate with. Can be configured via an environment variable `AWS_SECRET_ACCESS_KEY` or via a `secret_key` option in the server's config file.
- the **DynamoDB endpoint** to use. Can be configured via an environment variable `AWS_DYNAMODB_ENDPOINT` or via a `endpoint` option in the server's config file.
- the **AWS region** to use. Can be configured via an environment variable `AWS_DEFAULT_REGION` or via a `region` option in the server's config file.

**Example:**

```
backend "dynamodb" {                            
    table = "my-vault-dynamodb-table"
    region = "eu-west-1"
    advertise_addr = "http://127.0.0.1:8200"
}
```
